### PR TITLE
Allow setting amount in cents

### DIFF
--- a/lib/clieop/payment/batch.rb
+++ b/lib/clieop/payment/batch.rb
@@ -20,7 +20,7 @@ module Clieop
       # :description A description for this transaction (4 lines max)
       def add_transaction (transaction)
         raise "No :account_nr given"    if transaction[:account_nr].nil?
-        raise "No :amount given"        if transaction[:amount].nil?
+        raise "No :amount given"        if transaction[:amount].nil? && transaction[:amount_in_cents].nil?
         raise "No :account_owner given" if transaction[:account_owner].nil?
         @transactions << transaction
       end
@@ -59,7 +59,7 @@ module Clieop
           transaction_type = tr[:transaction_type] || (transaction_is_payment? ? 1002 : 0)
           to_account       = transaction_is_payment? ? @batch_info[:account_nr] : tr[:account_nr]
           from_account     = transaction_is_payment? ? tr[:account_nr] : @batch_info[:account_nr]
-          amount_in_cents  = (tr[:amount] * 100).round.to_i
+          amount_in_cents  = tr.fetch(:amount_in_cents) { (tr[:amount] * 100).round }.to_i
 
           # update checksums
           total_account += tr[:account_nr].to_i

--- a/spec/clieop/payment/batch_spec.rb
+++ b/spec/clieop/payment/batch_spec.rb
@@ -107,6 +107,17 @@ describe Clieop::Payment::Batch do
         @batch << @transaction
       end
 
+      it 'should allow specifying amount in cents' do
+        batch_with_cents = Clieop::Payment::Batch.payment_batch(@batch_info.dup)
+        batch_with_euros = Clieop::Payment::Batch.payment_batch(@batch_info.dup)
+        transaction_in_cents = @transaction.dup
+        transaction_in_cents.delete(:amount)
+        transaction_in_cents[:amount_in_cents] = 3010200
+        batch_with_cents << transaction_in_cents
+        batch_with_euros << @transaction
+        batch_with_cents.to_clieop.should == batch_with_euros.to_clieop
+      end
+
       it "should add transactions to batch" do
         @batch.batch_info[:transaction_group].should eql(0)
         @batch.to_clieop.should  match(/0010B0001234567890001EUR                          /)


### PR DESCRIPTION
As per https://github.com/wvanbergen/clieop/blob/master/lib/clieop/payment/batch.rb#L62, the gem currently seems to require you to pass in money as a Float. It seems to me that the library should not force this decision on the caller. My application happens to store money in cents, and now I am forced to convert my cents to euros, because the Clieop gem insists to conver the  amount to cents.

Then again, it _is_ a nice convenience function for when you do want to pass in an amount in euros.

Would it possible to allow both? Maybe allow passing in options `:amount_in_cents` or `:amount_in_euros`, so the caller can choose to have its value converted or not?

Maybe you could do something like this to allow the value in cents and defaulting to the old behaviour in euros:

``` ruby
amount_in_cents  = tr.fetch(:amount_in_cents) { (tr[:amount] * 100).round.to_i }
```
